### PR TITLE
[ERE-764] Fix issue with 'Add a patient' action not being visible in parent page

### DIFF
--- a/angelman/angelman/templates/rdrf_cdes/parent.html
+++ b/angelman/angelman/templates/rdrf_cdes/parent.html
@@ -64,13 +64,11 @@
             </ul>
         </div>
 
-        {% if request.user.is_parent %}
-            <div class="btn-group" role="group" aria-label="...">
-                <button id="add-patient-btn" class="btn btn-success" data-toggle="modal" data-target="#new_patient_modal">
-                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>{% trans 'Add a Patient' %}
-                </button>
-            </div>
-        {% endif %}
+        <div class="btn-group" role="group" aria-label="...">
+            <button id="add-patient-btn" class="btn btn-success" data-toggle="modal" data-target="#new_patient_modal">
+                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>{% trans 'Add a Patient' %}
+            </button>
+        </div>
         <div class="modal fade" id="new_patient_modal" tabindex="-1" role="dialog" aria-labelledby="newPatientModal" aria-hidden="true">
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">

--- a/angelman/angelman/templates/rdrf_cdes/parent.html
+++ b/angelman/angelman/templates/rdrf_cdes/parent.html
@@ -49,28 +49,28 @@
     </script>
 {% endblock %}
 
-{% block extra_menu %}
-    {{ block.super }}
-    {% if request.user.is_parent %}
-        <li><a href="#" id="add-patient-btn" data-toggle="modal" data-target="#new_patient_modal"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {% trans 'Add a Patient' %}</a></li>
-    {% endif %}
-{% endblock %}
-
 {% block content %}
     {% if request.user.is_authenticated %}
         <blockquote>
             <h4>Welcome {{request.user.first_name}} {{request.user.last_name}} to the Angelman Registry</h4>
         </blockquote>
-        
+
         <div class="alert alert-warning">
             <ul>
                 <li>Please first provide your consent to participate in the registry by clicking on the link to 'Please sign consent'.</li>
                 <li>Once you have provided consent, you may access the Registry Forms by clicking on the 'Forms' dropdown.</li>
                 <li>To change your own personal details, click on "your name" (in the menu bar) and go to "Account".</li>
-                <li>To add another patient, click on "Menu" and go to "Add a patient".</li>
+                <li>To add another patient, click on "Add a patient".</li>
             </ul>
         </div>
 
+        {% if request.user.is_parent %}
+            <div class="btn-group" role="group" aria-label="...">
+                <button id="add-patient-btn" class="btn btn-success" data-toggle="modal" data-target="#new_patient_modal">
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>{% trans 'Add a Patient' %}
+                </button>
+            </div>
+        {% endif %}
         <div class="modal fade" id="new_patient_modal" tabindex="-1" role="dialog" aria-labelledby="newPatientModal" aria-hidden="true">
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">


### PR DESCRIPTION
Add an `Add a patient` button to the parent page as template block extension method doesn't work because of using `include` to handle sub templates.